### PR TITLE
Fix a bug

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [project]
 license = "Apache-2.0"
 org-name = "wso2"
-version = "0.8.25"
+version = "0.8.26"
 authors = ["WSO2"]
 repository = "https://github.com/wso2-ballerina/module-twilio"
 keywords = ["twilio", "sms", "call", "otp"]

--- a/twilio/twilio_endpoint.bal
+++ b/twilio/twilio_endpoint.bal
@@ -234,7 +234,7 @@ remote function Client.verifyOtp(string userId, string token) returns AuthyOtpVe
 public type TwilioConfiguration record {
     string accountSId;
     string authToken;
-    string xAuthyKey;
+    string xAuthyKey = "";
     http:ClientEndpointConfig basicClientConfig = {};
     http:ClientEndpointConfig authyClientConfig = {};
 };


### PR DESCRIPTION
## Purpose
- `xAuthyKey` is passed by the user if and only if he needs to activate the actions of Authy API